### PR TITLE
Add requirements.txt file

### DIFF
--- a/air1/requirements.txt
+++ b/air1/requirements.txt
@@ -1,0 +1,2 @@
+tornado
+pyserial


### PR DESCRIPTION
Adding requirements file with dependencies. Tested with Python 2 and virtualenv.

```
$ virtualenv dusty-acorn
$ source dusty-acorn/bin/activate
$ pip install -r air1/requirements.txt
```

Or perhaps this file should reside in the project source, though I'm not sure if there will be other modules. In which case, it would make more sense to have one requirements.txt per module in this repo.