### PR TITLE
Make the project Python3 compatible

### DIFF
--- a/air1/agent.py
+++ b/air1/agent.py
@@ -10,9 +10,7 @@ from threading import Thread
 
 # choose which pacman to use dynamically
 import importlib
-serial_device_class = "air1.pacman.Pacman"
-module_name, class_name = serial_device_class.rsplit('.', 1)
-SerialDeviceClass = getattr(importlib.import_module(module_name), class_name)
+from air1.pacman import Pacman
 
 class Agent(Thread):
     """ An agent. Tis a thread, used as the agent, responsible for listen to events to/from the UI, and interact with message queues appropriately """
@@ -47,7 +45,7 @@ class Agent(Thread):
         self.send_message_to_ui('Program started.')
         
         self.send_message_to_ui('Creating pacman device...')
-        self.pacman = SerialDeviceClass ()
+        self.pacman = Pacman()
 
     def send_message_to_ui(self, message):
         """ Sends messages to the UI, via the result queue """
@@ -69,7 +67,7 @@ class Agent(Thread):
                 task = self.taskQ.get()
 
                 # You can view the content of this message in the console where you started the program
-                print "Agent received from web: " + task
+                print("Agent received from web: " + task)
 
                 data = json.loads(task)
 

--- a/air1/pacman.py
+++ b/air1/pacman.py
@@ -96,7 +96,7 @@ class Pacman(object):
 		err_value = -99
 		if len(line) >0:
 			if (line[0].isdigit()):
-				p_vec = map(float,line.split())
+				p_vec = list(map(float,line.split()))
 				if (len(p_vec)>=13):
 					pm1 = p_vec[0] #0
 					dust =p_vec[1] #1

--- a/air1/web_server.py
+++ b/air1/web_server.py
@@ -11,7 +11,7 @@ from tornado.options import define, options, parse_command_line
 # for queues
 import multiprocessing
 # for the agent
-import agent
+from air1.agent import Agent
 
 define("port", default=8080, help="run on the given port", type=int)
 define("debug", default=False, help="run in debug mode")
@@ -155,16 +155,16 @@ def main():
     # listen to the port and start the app loop and wait for clients
     server = HTTPServer(app)
     server.listen(options.port)
-    print "Listening on port:", options.port
+    print("Listening on port:", options.port)
 
     def checkResults():
         if not resultQ.empty():
             result = resultQ.get()
-            #print "tornado received from agent: " + str(result)
+            #print("tornado received from agent: " + str(result))
             for c in clients:
                 c.write_message(result)
 
-    theAgent = agent.Agent(taskQ, resultQ)
+    theAgent = Agent(taskQ, resultQ)
     theAgent.daemon = True
     mainLoop = tornado.ioloop.IOLoop.instance()
     scheduler = tornado.ioloop.PeriodicCallback(checkResults, 500, io_loop = mainLoop)
@@ -179,5 +179,5 @@ def main():
         theAgent.close()
         scheduler.stop()
         mainLoop.stop()
-    print "Bye!"
+    print("Bye!")
     sys.exit(0)


### PR DESCRIPTION
Replaced `print ""` by `print()` statements, and since we do not have the fake pacman class, removed the use of `importlib` and now we are using the normal import system.

Tested on Python2 and 3, Ubuntu LTS, with VirtualEnv and Anaconda.